### PR TITLE
Read parquet

### DIFF
--- a/src/loader/utils/read_parquet.py
+++ b/src/loader/utils/read_parquet.py
@@ -1,3 +1,7 @@
+import io
+
+import boto3
+import pandas
 import pyarrow.parquet as pq
 
 
@@ -11,4 +15,16 @@ def read_parquet(file_name, bucket_name):
     Returns:
         <str> the contents of the parquet file in csv format.
     """
-    pass
+    buffer = io.BytesIO()
+    s3 = boto3.resource('s3')
+
+    object = s3.Object(bucket_name, file_name)
+    object.download_fileobj(buffer)
+
+    dataframe = pandas.read_parquet(buffer)
+    csv_data = dataframe.to_csv(index=False)
+
+    if csv_data == '\n':
+        return ''
+    else:
+        return csv_data

--- a/src/loader/utils/read_parquet.py
+++ b/src/loader/utils/read_parquet.py
@@ -1,0 +1,2 @@
+def read_parquet(file_name, bucket_name):
+    pass

--- a/src/loader/utils/read_parquet.py
+++ b/src/loader/utils/read_parquet.py
@@ -2,7 +2,6 @@ import io
 
 import boto3
 import pandas
-import pyarrow.parquet as pq
 
 
 def read_parquet(file_name, bucket_name):

--- a/src/loader/utils/read_parquet.py
+++ b/src/loader/utils/read_parquet.py
@@ -1,2 +1,14 @@
+import pyarrow.parquet as pq
+
+
 def read_parquet(file_name, bucket_name):
+    """Reads the contents of a parquet file in an AWS S3 bucket.
+
+    Args:
+        file_name <string> the name of the parquet file.
+        bucket_name <string> the name of the S3 bucket containing the file.
+
+    Returns:
+        <str> the contents of the parquet file in csv format.
+    """
     pass

--- a/test/test_loader/test_read_parquet.py
+++ b/test/test_loader/test_read_parquet.py
@@ -1,0 +1,71 @@
+import os
+import pytest
+
+import boto3
+from moto import mock_s3
+
+from src.processor.utils.convert_and_dump_parquet import convert_and_dump_parquet  # noqa: E501
+from src.loader.utils.read_parquet import read_parquet
+
+
+class TestReadParquet:
+    @pytest.fixture(scope="function")
+    def aws_credentials(self):
+        """Mocked AWS Credentials for moto."""
+
+        os.environ["AWS_ACCESS_KEY_ID"] = "test"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "test"
+        os.environ["AWS_SECURITY_TOKEN"] = "test"
+        os.environ["AWS_SESSION_TOKEN"] = "test"
+        os.environ["AWS_DEFAULT_REGION"] = "eu-west-2"
+
+    @pytest.fixture(scope="function")
+    def s3(self, aws_credentials):
+        with mock_s3():
+            yield boto3.client("s3", region_name="eu-west-2")
+
+    @pytest.fixture(autouse=True)
+    def empty_bucket(self, s3):
+        s3.create_bucket(
+            Bucket="test_processed_bucket",
+            CreateBucketConfiguration={"LocationConstraint": "eu-west-2"},
+        )
+
+    @pytest.fixture(autouse=True)
+    def create_test_parquet_files(self, empty_bucket, s3):
+        test_parquet_data = [
+            {"staff_id": 1, "first_name": "Jeremie", "last_name": "Franey"},
+            {"staff_id": 2, "first_name": "Deron", "last_name": "Beier"},
+            {"staff_id": 3, "first_name": "Jeanette", "last_name": "Erdman"},
+        ]
+
+        test_parquet_file = convert_and_dump_parquet(  # noqa: F841
+            "test_parquet_file",
+            test_parquet_data,
+            "test_processed_bucket"
+        )
+
+        empty_parquet_file = convert_and_dump_parquet(  # noqa: F841
+            "test_parquet_file", [], "test_processed_bucket"
+        )
+
+    def test_returns_string(self):
+        result = read_parquet("test_parquet_file", "test_processed_bucket")
+
+        assert isinstance(result, str)
+
+    def test_returns_empty_str_if_passed_empty_file(self):
+        result = read_parquet("empty_parquet_file", "test_processed_bucket")
+
+        assert result == ""
+
+    def test_returns_contents_of_parquet_file(self):
+        expected = """staff_id,first_name,last_name
+1,Jeremie,Franey
+2,Deron,Beier
+3,Jeanette,Erdman
+"""
+
+        result = read_parquet("test_parquet_file", "test_processed_bucket")
+
+        assert result == expected.strip()

--- a/test/test_loader/test_read_parquet.py
+++ b/test/test_loader/test_read_parquet.py
@@ -24,7 +24,7 @@ class TestReadParquet:
         with mock_s3():
             yield boto3.client("s3", region_name="eu-west-2")
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture
     def empty_bucket(self, s3):
         s3.create_bucket(
             Bucket="test_processed_bucket",
@@ -39,23 +39,27 @@ class TestReadParquet:
             {"staff_id": 3, "first_name": "Jeanette", "last_name": "Erdman"},
         ]
 
-        test_parquet_file = convert_and_dump_parquet(  # noqa: F841
-            "test_parquet_file",
-            test_parquet_data,
-            "test_processed_bucket"
+        convert_and_dump_parquet(
+            filename="test_parquet_file.csv",
+            transformed_data=test_parquet_data,
+            bucket_name="test_processed_bucket"
         )
 
-        empty_parquet_file = convert_and_dump_parquet(  # noqa: F841
-            "test_parquet_file", [], "test_processed_bucket"
+        convert_and_dump_parquet(
+            filename="empty_parquet_file.csv",
+            transformed_data=[],
+            bucket_name="test_processed_bucket"
         )
 
     def test_returns_string(self):
-        result = read_parquet("test_parquet_file", "test_processed_bucket")
+        result = read_parquet("test_parquet_file.parquet",
+                              "test_processed_bucket")
 
         assert isinstance(result, str)
 
     def test_returns_empty_str_if_passed_empty_file(self):
-        result = read_parquet("empty_parquet_file", "test_processed_bucket")
+        result = read_parquet("empty_parquet_file.parquet",
+                              "test_processed_bucket")
 
         assert result == ""
 
@@ -66,6 +70,7 @@ class TestReadParquet:
 3,Jeanette,Erdman
 """
 
-        result = read_parquet("test_parquet_file", "test_processed_bucket")
+        result = read_parquet("test_parquet_file.parquet",
+                              "test_processed_bucket")
 
-        assert result == expected.strip()
+        assert result == expected


### PR DESCRIPTION
Add function read_paruqet, which reads the contents of a parquet file in an AWS S3 bucket and returns a string of data in csv format. Takes two arguments:

file_name <string> the key of the parquet file in the S3 bucket.
bucket_name <string> the name of the S3 bucket containing the file.