### PR TITLE
modify convert_and_dump_parquet to give dumped parquet files correct names

### DIFF
--- a/src/processor/utils/convert_and_dump_parquet.py
+++ b/src/processor/utils/convert_and_dump_parquet.py
@@ -6,8 +6,19 @@ from io import BytesIO
 
 
 def generate_object_key(filename):
-    extracted_name = filename[:-3]
-    return f"{extracted_name}parquet"
+    table_name_converter = {
+        'design': 'dim_design',
+        'staff': 'dim_staff',
+        'counterparty': 'dim_counterparty',
+        'currency': 'dim_currency',
+        'sales_order': 'fact_sales_order',
+        'address': 'dim_location'
+    }
+    old_table_name = filename.split('/')[0]
+    new_table_name = table_name_converter[old_table_name]
+    date = filename.split('/')[1]
+    timestamp = filename.split('/')[2][:-4]
+    return f"{new_table_name}/{date}/{timestamp}.parquet"
 
 
 def convert_and_dump_parquet(filename,

--- a/test/test_loader/test_fetch_new_files.py
+++ b/test/test_loader/test_fetch_new_files.py
@@ -37,25 +37,25 @@ class TestFetchNewFile:
     @pytest.fixture(autouse=True)
     def create_test_files(self, empty_bucket, s3):
         convert_and_dump_parquet(
-            filename="dim_staff/02-11-2024/02-11-2024-142200.csv",
+            filename="staff/02-11-2024/02-11-2024-142200.csv",
             transformed_data=[],
             bucket_name="test_processed_bucket"
         )
 
         convert_and_dump_parquet(
-            filename="dim_staff/02-11-2024/02-11-2024-142300.csv",
+            filename="staff/02-11-2024/02-11-2024-142300.csv",
             transformed_data=[],
             bucket_name="test_processed_bucket"
         )
 
         convert_and_dump_parquet(
-            filename="dim_staff/02-11-2024/02-11-2024-142400.csv",
+            filename="staff/02-11-2024/02-11-2024-142400.csv",
             transformed_data=[],
             bucket_name="test_processed_bucket"
         )
 
         convert_and_dump_parquet(
-            filename="dim_staff/02-11-2024/02-11-2024-142500.csv",
+            filename="staff/02-11-2024/02-11-2024-142500.csv",
             transformed_data=[],
             bucket_name="test_processed_bucket"
         )
@@ -128,10 +128,10 @@ class TestFetchNewFile:
 class TestSortNewFiles:
     def test_sorts_by_timestamp(self):
         unsorted_file_names = [
-           'dim_staff/02-11-2024/02-11-2024-142500.parquet',
-           'dim_staff/02-11-2024/02-11-2024-132500.parquet',
-           'dim_staff/02-11-2024/02-11-2024-152500.parquet',
-           'dim_staff/02-11-2024/02-11-2024-102500.parquet'
+            'dim_staff/02-11-2024/02-11-2024-142500.parquet',
+            'dim_staff/02-11-2024/02-11-2024-132500.parquet',
+            'dim_staff/02-11-2024/02-11-2024-152500.parquet',
+            'dim_staff/02-11-2024/02-11-2024-102500.parquet'
         ]
 
         expected = [
@@ -145,10 +145,10 @@ class TestSortNewFiles:
 
     def test_if_same_timestamp_sorts_by_table_name(self):
         unsorted_file_names = [
-           'dim_staff/02-11-2024/02-11-2024-142500.parquet',
-           'fact_sales_order/02-11-2024/02-11-2024-142500.parquet',
-           'dim_design/02-11-2024/02-11-2024-142500.parquet',
-           'fact_sales_order/02-11-2024/02-11-2024-140000.parquet'
+            'dim_staff/02-11-2024/02-11-2024-142500.parquet',
+            'fact_sales_order/02-11-2024/02-11-2024-142500.parquet',
+            'dim_design/02-11-2024/02-11-2024-142500.parquet',
+            'fact_sales_order/02-11-2024/02-11-2024-140000.parquet'
         ]
 
         expected = [

--- a/test/test_loader/test_read_parquet.py
+++ b/test/test_loader/test_read_parquet.py
@@ -40,25 +40,25 @@ class TestReadParquet:
         ]
 
         convert_and_dump_parquet(
-            filename="test_parquet_file.csv",
+            filename="staff/31-10-2023/31-10-2023-152600.csv",
             transformed_data=test_parquet_data,
             bucket_name="test_processed_bucket"
         )
 
         convert_and_dump_parquet(
-            filename="empty_parquet_file.csv",
+            filename="staff/31-10-2023/31-10-2023-162600.csv",
             transformed_data=[],
             bucket_name="test_processed_bucket"
         )
 
     def test_returns_string(self):
-        result = read_parquet("test_parquet_file.parquet",
+        result = read_parquet("dim_staff/31-10-2023/31-10-2023-152600.parquet",
                               "test_processed_bucket")
 
         assert isinstance(result, str)
 
     def test_returns_empty_str_if_passed_empty_file(self):
-        result = read_parquet("empty_parquet_file.parquet",
+        result = read_parquet("dim_staff/31-10-2023/31-10-2023-162600.parquet",
                               "test_processed_bucket")
 
         assert result == ""
@@ -70,7 +70,7 @@ class TestReadParquet:
 3,Jeanette,Erdman
 """
 
-        result = read_parquet("test_parquet_file.parquet",
+        result = read_parquet("dim_staff/31-10-2023/31-10-2023-152600.parquet",
                               "test_processed_bucket")
 
         assert result == expected

--- a/test/test_processor/test_convert_and_dump_parquet.py
+++ b/test/test_processor/test_convert_and_dump_parquet.py
@@ -9,10 +9,22 @@ from src.processor.utils.convert_and_dump_parquet import (
 
 
 class TestGenerateObjectKey:
-    def test_generate_object_key(self):
-        expected = "test_table/31-10-2023/31-10-2023-152600.parquet"
+    def test_generates_file_name_matching_star_schema_tables(self):
+        expected = "dim_design/31-10-2023/31-10-2023-152600.parquet"
         result = generate_object_key(
-            "test_table/31-10-2023/31-10-2023-152600.csv"
+            "design/31-10-2023/31-10-2023-152600.csv"
+        )
+        assert result == expected
+
+        expected = "fact_sales_order/31-10-2023/31-10-2023-152600.parquet"
+        result = generate_object_key(
+            "sales_order/31-10-2023/31-10-2023-152600.csv"
+        )
+        assert result == expected
+
+        expected = "dim_location/31-10-2023/31-10-2023-152600.parquet"
+        result = generate_object_key(
+            "address/31-10-2023/31-10-2023-152600.csv"
         )
         assert result == expected
 
@@ -46,24 +58,24 @@ class TestDumpParquet:
 
     def test_puts_parquet_file_in_bucket(self, s3, test_data, empty_bucket):
         convert_and_dump_parquet(
-            "test_table/31-10-2023/31-10-2023-152600.csv",
+            "design/31-10-2023/31-10-2023-152600.csv",
             test_data,
             "test_processed_bucket"
         )
         response = s3.list_objects(Bucket="test_processed_bucket")
         filename = response["Contents"][0]["Key"]
-        assert filename == "test_table/31-10-2023/31-10-2023-152600.parquet"
+        assert filename == "dim_design/31-10-2023/31-10-2023-152600.parquet"
 
     def test_returns_the_created_file_name(self, test_data, empty_bucket):
         assert convert_and_dump_parquet(
-            "test_table/31-10-2023/31-10-2023-152600.csv",
+            "design/31-10-2023/31-10-2023-152600.csv",
             test_data,
             "test_processed_bucket"
-        ) == "test_table/31-10-2023/31-10-2023-152600.parquet"
+        ) == "dim_design/31-10-2023/31-10-2023-152600.parquet"
 
     def test_raises_an_error(self, test_data):
         with pytest.raises(Exception):
             convert_and_dump_parquet(
-                "test_table/31-10-2023/31-10-2023-152600.csv",
+                "design/31-10-2023/31-10-2023-152600.csv",
                 test_data,
                 "invalid_bucket")


### PR DESCRIPTION
... which match destination dim/fact tables.

modify test_convert_and_dump_parquet, test_fetch_new_files and test_read_parquet to incorporate revised file names