### PR TITLE
modify processor lambda so convert_and_dump_parquet is not called if …

### DIFF
--- a/src/processor/processor.py
+++ b/src/processor/processor.py
@@ -39,11 +39,13 @@ def lambda_handler(event, context):
 
         data_to_transform = read_csv(filename, read_bucket_name)
         transformed_data = transform_data(filename, data_to_transform)
-        new_filename = convert_and_dump_parquet(filename,
-                                                transformed_data,
-                                                dump_bucket_name)
+        if transformed_data is not None:
+            new_filename = convert_and_dump_parquet(filename,
+                                                    transformed_data,
+                                                    dump_bucket_name)
 
-        logger.info(f"File {new_filename} added to bucket {dump_bucket_name}")
+            logger.info(
+                f"File {new_filename} added to bucket {dump_bucket_name}")
 
     except InterfaceError:
         logger.error("Error interacting with database.")

--- a/test/test_processor/test_processor.py
+++ b/test/test_processor/test_processor.py
@@ -21,12 +21,12 @@ def test_data():
 @pytest.fixture
 def test_event():
     return {"Records": [
-                {
-                    "s3": {
-                        "object": {"key": "test_path/test_name.csv"},
-                        "bucket": {"name": "test_read_bucket"}}
-                }
-            ]}
+        {
+            "s3": {
+                "object": {"key": "test_path/test_name.csv"},
+                "bucket": {"name": "test_read_bucket"}}
+        }
+    ]}
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -66,6 +66,17 @@ class TestUtilFunctions:
         mock_convert_and_dump.assert_called_once_with(
             "test_path/test_name.csv", test_data, "test_dump_bucket"
         )
+
+    def test_if_transform_data_returns_None_no_parquet_created(self,
+                                                               mock_read,
+                                                               mock_transform,
+                                                               mock_convert):
+        mock_read.return_value = ''
+        mock_transform.return_value = None
+
+        lambda_handler(event=test_event, context=None)
+
+        assert mock_convert.call_count == 0
 
 
 @patch("src.processor.processor.logger")


### PR DESCRIPTION
…transform_data returns None.

update test_processor to check convert_and_dump_parquet call-count is zero if transform_data returns None.