### PR TITLE
Transform data error handling

### DIFF
--- a/src/processor/utils/transform_data.py
+++ b/src/processor/utils/transform_data.py
@@ -17,10 +17,17 @@ def transform_data(file_name, data):
         <list><dict> the transformed data as a list of dictionaries.
             Returns an empty list if the data has no transformation available.
     """
-    transform_to_apply = "transform_" + file_name.split('/')[0]
-    transformed_data = globals()[transform_to_apply](data)
+    try:
+        table_name = file_name.split('/')[0]
+        transform_to_apply = "transform_" + table_name
+        transformed_data = globals()[transform_to_apply](data)
 
-    return transformed_data
+        return transformed_data
+
+    except Exception as e:
+        if e == KeyError:
+            print(f'No available transformation for {table_name}')
+            return None
 
 
 def apply_data_type(string, data_type):

--- a/src/processor/utils/transform_data.py
+++ b/src/processor/utils/transform_data.py
@@ -6,6 +6,17 @@ from pg8000.native import Connection, identifier, literal
 
 
 def transform_data(file_name, data):
+    """Transforms data from source tables into star schema format.
+
+    Args:
+        file_name <string> the file name where the data is stored.
+            Used for accessing the correct table transformation function.
+        data <list><dict> the data to be transformed.
+
+    Returns:
+        <list><dict> the transformed data as a list of dictionaries.
+            Returns an empty list if the data has no transformation available.
+    """
     transform_to_apply = "transform_" + file_name.split('/')[0]
     transformed_data = globals()[transform_to_apply](data)
 

--- a/test/test_processor/test_transform_data.py
+++ b/test/test_processor/test_transform_data.py
@@ -41,10 +41,11 @@ class TestTransformData:
     def test_file_name(self):
         return "design/31-10-2023/31-10-2023-152600.csv"
 
-    def test_returns_a_list_of_dictionaries(self,
-                                            test_file_name,
-                                            test_design_data  # noqa: F811
-                                            ):
+    def test_returns_a_list_of_dictionaries(
+        self,
+        test_file_name,
+        test_design_data  # noqa: F811
+    ):
         test_input_design_data, _ = test_design_data
 
         result = transform_data(test_file_name, test_input_design_data)
@@ -54,12 +55,20 @@ class TestTransformData:
         for item in result:
             assert isinstance(item, dict)
 
+    def test_returns_an_empty_list_if_no_transform_function_found(
+        self,
+        test_file_name,
+        test_design_data  # noqa: F811
+    ):
+        pass
+
     @patch("src.processor.utils.transform_data.transform_design")
-    def test_calls_the_appropriate_transform_data_function(self,
-                                                           mock_transform_design,  # noqa: E501
-                                                           test_file_name,
-                                                           test_design_data  # noqa: F811,E501
-                                                           ):
+    def test_calls_the_appropriate_transform_data_function(
+        self,
+        mock_transform_design,
+        test_file_name,
+        test_design_data  # noqa: F811
+    ):
         test_input_design_data, _ = test_design_data
 
         transform_data(test_file_name, test_input_design_data)
@@ -67,10 +76,11 @@ class TestTransformData:
         assert mock_transform_design.call_count == 1
         assert mock_transform_design.called_with(test_input_design_data)
 
-    def test_returns_transformed_data(self,
-                                      test_file_name,
-                                      test_design_data  # noqa: F811
-                                      ):
+    def test_returns_transformed_data(
+        self,
+        test_file_name,
+        test_design_data  # noqa: F811
+    ):
         test_input_design_data, test_output_design_data = test_design_data
 
         result = transform_data(test_file_name, test_input_design_data)
@@ -365,8 +375,10 @@ class TestTransformAddress():
 
 
 class TestTransformPayment():
-    def test_returns_list_of_dictionaries(self,
-                                          test_payment_data):  # noqa: F811
+    def test_returns_list_of_dictionaries(
+        self,
+        test_payment_data  # noqa: F811
+    ):
         test_input_payment_data, test_output_payment_data = test_payment_data
 
         result = transform_payment(test_input_payment_data)
@@ -390,8 +402,10 @@ class TestTransformPayment():
 
 
 class TestTransformPurchaseOrder():
-    def test_returns_list_of_dictionaries(self,
-                                          test_purchase_order_data):  # noqa: F811,E501
+    def test_returns_list_of_dictionaries(
+        self,
+        test_purchase_order_data  # noqa: F811
+    ):
         test_input_purchase_order_data, test_output_purchase_order_data = test_purchase_order_data  # noqa: 501
 
         result = transform_purchase_order(test_input_purchase_order_data)
@@ -415,8 +429,10 @@ class TestTransformPurchaseOrder():
 
 
 class TestTransformPaymentType():
-    def test_returns_list_of_dictionaries(self,
-                                          test_payment_type_data):  # noqa: F811,E501
+    def test_returns_list_of_dictionaries(
+        self,
+        test_payment_type_data    # noqa: F811
+    ):
         test_input_payment_type_data, test_output_payment_type_data = test_payment_type_data  # noqa: 501
 
         result = transform_payment_type(test_input_payment_type_data)
@@ -440,8 +456,10 @@ class TestTransformPaymentType():
 
 
 class TestTransformTransaction():
-    def test_returns_list_of_dictionaries(self,
-                                          test_transaction_data):  # noqa: F811
+    def test_returns_list_of_dictionaries(
+        self,
+        test_transaction_data  # noqa: F811
+    ):
         test_input_transaction_data, test_output_transaction_data = test_transaction_data  # noqa: 501
 
         result = transform_transaction(test_input_transaction_data)
@@ -457,7 +475,10 @@ class TestTransformTransaction():
     ):
         assert transform_transaction([]) == []
 
-    def test_returns_transformed_data(self, test_transaction_data):  # noqa: 501
+    def test_returns_transformed_data(
+        self,
+        test_transaction_data  # noqa: F811
+    ):
         test_input_transaction_data, test_output_transaction_data = test_transaction_data  # noqa: 501
         result = transform_transaction(test_input_transaction_data)
         expected = test_output_transaction_data

--- a/test/test_processor/test_transform_data.py
+++ b/test/test_processor/test_transform_data.py
@@ -47,7 +47,6 @@ class TestTransformData:
         test_design_data  # noqa: F811
     ):
         test_input_design_data, _ = test_design_data
-
         result = transform_data(test_file_name, test_input_design_data)
 
         assert isinstance(result, list)
@@ -57,10 +56,20 @@ class TestTransformData:
 
     def test_returns_an_empty_list_if_no_transform_function_found(
         self,
-        test_file_name,
         test_design_data  # noqa: F811
     ):
-        pass
+        test_input_design_data, _ = test_design_data
+        result = transform_data("non_existent_table", test_design_data)
+
+        assert result is None
+
+    def test_returns_an_empty_list_if_passed_empty_data(
+        self,
+        test_file_name
+    ):
+        result = transform_data(test_file_name, [])
+
+        assert result == []
 
     @patch("src.processor.utils.transform_data.transform_design")
     def test_calls_the_appropriate_transform_data_function(
@@ -70,7 +79,6 @@ class TestTransformData:
         test_design_data  # noqa: F811
     ):
         test_input_design_data, _ = test_design_data
-
         transform_data(test_file_name, test_input_design_data)
 
         assert mock_transform_design.call_count == 1
@@ -82,7 +90,6 @@ class TestTransformData:
         test_design_data  # noqa: F811
     ):
         test_input_design_data, test_output_design_data = test_design_data
-
         result = transform_data(test_file_name, test_input_design_data)
 
         assert result == test_output_design_data


### PR DESCRIPTION
Add docstring for transform_data.
Add error handling for passing transform_data a file containing an invalid table name.
Add unit tests for handling invalid table names and empty data lists.