### PR TITLE
Transform payment

### DIFF
--- a/src/processor/utils/transform_data.py
+++ b/src/processor/utils/transform_data.py
@@ -29,9 +29,13 @@ def transform_data(file_name, data):
         return None
 
 
-def apply_data_type(string, data_type):
+def apply_data_type(string, data_type, table_name=None):
     if string == '':
-        return None
+        if table_name == 'transaction':
+            print('transaction table')
+            return 0
+        else:
+            return None
     elif data_type == int:
         return int(float(string))
     elif data_type == float:
@@ -308,10 +312,15 @@ def transform_transaction(data):
         {
             "transaction_id": apply_data_type(row["transaction_id"], int),
             "transaction_type": row["transaction_type"],
-            "sales_order_id": apply_data_type(row["sales_order_id"], int),
+            "sales_order_id": apply_data_type(
+                row["sales_order_id"],
+                int,
+                'transaction'
+            ),
             "purchase_order_id": apply_data_type(
                 row["purchase_order_id"],
-                int
+                int,
+                'transaction'
             )
         }
         for row in data

--- a/src/processor/utils/transform_data.py
+++ b/src/processor/utils/transform_data.py
@@ -33,7 +33,7 @@ def apply_data_type(string, data_type):
     if string == '':
         return ''
     elif data_type == int:
-        return int(string)
+        return int(float(string))
     elif data_type == float:
         return float(string)
 
@@ -239,26 +239,26 @@ def transform_address(data):
     return transformed_data
 
 
-# def transform_payment(data):
-#     transformed_data = [
-#         {
-#             "payment_id": apply_data_type(row["payment_id"], int),
-#             "created_date": row["created_at"][:10],
-#             "created_time": row["created_at"][11:],
-#             "last_updated_date": row["last_updated"][:10],
-#             "last_updated": row["last_updated"][11:],
-#             "transaction_id": apply_data_type(row["transaction_id"], int),
-#             "counterparty_id": apply_data_type(row["counterparty_id"], int),
-#             "payment_amount": apply_data_type(row["payment_amount"], float),
-#             "currency_id": apply_data_type(row["currency_id"], int),
-#             "payment_type_id": apply_data_type(row["payment_type_id"], int),
-#             "paid": row["paid"],
-#             "payment_date": row["payment_date"]
-#         }
-#         for row in data
-#     ]
+def transform_payment(data):
+    transformed_data = [
+        {
+            "payment_id": apply_data_type(row["payment_id"], int),
+            "created_date": row["created_at"][:10],
+            "created_time": row["created_at"][11:],
+            "last_updated_date": row["last_updated"][:10],
+            "last_updated": row["last_updated"][11:],
+            "transaction_id": apply_data_type(row["transaction_id"], int),
+            "counterparty_id": apply_data_type(row["counterparty_id"], int),
+            "payment_amount": apply_data_type(row["payment_amount"], float),
+            "currency_id": apply_data_type(row["currency_id"], int),
+            "payment_type_id": apply_data_type(row["payment_type_id"], int),
+            "paid": row["paid"],
+            "payment_date": row["payment_date"]
+        }
+        for row in data
+    ]
 
-#     return transformed_data
+    return transformed_data
 
 
 def transform_purchase_order(data):
@@ -303,21 +303,21 @@ def transform_payment_type(data):
     return transformed_data
 
 
-# def transform_transaction(data):
-#     transformed_data = [
-#         {
-#             "transaction_id": apply_data_type(row["transaction_id"], int),
-#             "transaction_type": row["transaction_type"],
-#             "sales_order_id": apply_data_type(row["sales_order_id"], int),
-#             "purchase_order_id": apply_data_type(
-#                 row["purchase_order_id"],
-#                 int
-#             )
-#         }
-#         for row in data
-#     ]
+def transform_transaction(data):
+    transformed_data = [
+        {
+            "transaction_id": apply_data_type(row["transaction_id"], int),
+            "transaction_type": row["transaction_type"],
+            "sales_order_id": apply_data_type(row["sales_order_id"], int),
+            "purchase_order_id": apply_data_type(
+                row["purchase_order_id"],
+                int
+            )
+        }
+        for row in data
+    ]
 
-#     return transformed_data
+    return transformed_data
 
 
 def transform_department(data):

--- a/src/processor/utils/transform_data.py
+++ b/src/processor/utils/transform_data.py
@@ -31,7 +31,7 @@ def transform_data(file_name, data):
 
 def apply_data_type(string, data_type):
     if string == '':
-        return ''
+        return None
     elif data_type == int:
         return int(float(string))
     elif data_type == float:

--- a/test/test_processor/fixtures/transform_transaction_data.py
+++ b/test/test_processor/fixtures/transform_transaction_data.py
@@ -32,19 +32,19 @@ def test_transaction_data():
         {
             "transaction_id": 1,
             "transaction_type": 'PURCHASE',
-            "sales_order_id": '',
+            "sales_order_id": None,
             "purchase_order_id": 2,
         },
         {
             "transaction_id": 2,
             "transaction_type": 'PURCHASE',
-            "sales_order_id": '',
+            "sales_order_id": None,
             "purchase_order_id": 3,
         }, {
             "transaction_id": 3,
             "transaction_type": 'SALE',
             "sales_order_id": 1,
-            "purchase_order_id": '',
+            "purchase_order_id": None,
         }
     ]
 

--- a/test/test_processor/fixtures/transform_transaction_data.py
+++ b/test/test_processor/fixtures/transform_transaction_data.py
@@ -32,19 +32,19 @@ def test_transaction_data():
         {
             "transaction_id": 1,
             "transaction_type": 'PURCHASE',
-            "sales_order_id": None,
+            "sales_order_id": 0,
             "purchase_order_id": 2,
         },
         {
             "transaction_id": 2,
             "transaction_type": 'PURCHASE',
-            "sales_order_id": None,
+            "sales_order_id": 0,
             "purchase_order_id": 3,
         }, {
             "transaction_id": 3,
             "transaction_type": 'SALE',
             "sales_order_id": 1,
-            "purchase_order_id": None,
+            "purchase_order_id": 0,
         }
     ]
 

--- a/test/test_processor/test_transform_data.py
+++ b/test/test_processor/test_transform_data.py
@@ -18,9 +18,10 @@ from src.processor.utils.transform_data import (
     transform_staff,
     transform_sales_order,
     transform_address,
-    # transform_payment,
+    transform_payment,
     transform_purchase_order,
     transform_payment_type,
+    transform_transaction
 )
 
 from fixtures.transform_counterparty_data import test_counterparty_data  # noqa: F401,E501
@@ -29,10 +30,10 @@ from fixtures.transform_design_data import test_design_data  # noqa: F401
 from fixtures.transform_staff_data import test_staff_data  # noqa: F401
 from fixtures.transform_sales_data import test_sales_data  # noqa: F401
 from fixtures.transform_address_data import test_address_data  # noqa: F401
-# from fixtures.transform_payment_data import test_payment_data  # noqa: F401
+from fixtures.transform_payment_data import test_payment_data  # noqa: F401
 from fixtures.transform_purchase_order_data import test_purchase_order_data  # noqa: F401,E501
 from fixtures.transform_payment_type_data import test_payment_type_data  # noqa: F401,E501
-# from fixtures.transform_transaction_data import test_transaction_data  # noqa: F401,E501
+from fixtures.transform_transaction_data import test_transaction_data  # noqa: F401,E501
 
 
 class TestTransformData:
@@ -380,31 +381,31 @@ class TestTransformAddress():
         assert result == expected
 
 
-# class TestTransformPayment():
-#     def test_returns_list_of_dictionaries(
-#         self,
-#         test_payment_data  # noqa: F811
-#     ):
-#         test_input_payment_data, test_output_payment_data = test_payment_data
+class TestTransformPayment():
+    def test_returns_list_of_dictionaries(
+        self,
+        test_payment_data  # noqa: F811
+    ):
+        test_input_payment_data, test_output_payment_data = test_payment_data
 
-#         result = transform_payment(test_input_payment_data)
+        result = transform_payment(test_input_payment_data)
 
-#         assert isinstance(result, list)
+        assert isinstance(result, list)
 
-#         for item in result:
-#             assert isinstance(item, dict)
+        for item in result:
+            assert isinstance(item, dict)
 
-#     def test_returns_empty_list_if_passed_file_with_no_data(
-#         self,
-#         test_payment_data  # noqa: F811
-#     ):
-#         assert transform_payment([]) == []
+    def test_returns_empty_list_if_passed_file_with_no_data(
+        self,
+        test_payment_data  # noqa: F811
+    ):
+        assert transform_payment([]) == []
 
-#     def test_returns_transformed_data(self, test_payment_data):  # noqa: F811
-#         test_input_payment_data, test_output_payment_data = test_payment_data
-#         result = transform_payment(test_input_payment_data)
-#         expected = test_output_payment_data
-#         assert result == expected
+    def test_returns_transformed_data(self, test_payment_data):  # noqa: F811
+        test_input_payment_data, test_output_payment_data = test_payment_data
+        result = transform_payment(test_input_payment_data)
+        expected = test_output_payment_data
+        assert result == expected
 
 
 class TestTransformPurchaseOrder():
@@ -461,31 +462,31 @@ class TestTransformPaymentType():
         assert result == expected
 
 
-# class TestTransformTransaction():
-#     def test_returns_list_of_dictionaries(
-#         self,
-#         test_transaction_data  # noqa: F811
-#     ):
-#         test_input_transaction_data, test_output_transaction_data = test_transaction_data  # noqa: 501
+class TestTransformTransaction():
+    def test_returns_list_of_dictionaries(
+        self,
+        test_transaction_data  # noqa: F811
+    ):
+        test_input_transaction_data, test_output_transaction_data = test_transaction_data  # noqa: 501
 
-#         result = transform_transaction(test_input_transaction_data)
+        result = transform_transaction(test_input_transaction_data)
 
-#         assert isinstance(result, list)
+        assert isinstance(result, list)
 
-#         for item in result:
-#             assert isinstance(item, dict)
+        for item in result:
+            assert isinstance(item, dict)
 
-    # def test_returns_empty_list_if_passed_file_with_no_data(
-    #     self,
-    #     test_transaction_data  # noqa: F811
-    # ):
-    #     assert transform_transaction([]) == []
+    def test_returns_empty_list_if_passed_file_with_no_data(
+        self,
+        test_transaction_data  # noqa: F811
+    ):
+        assert transform_transaction([]) == []
 
-    # def test_returns_transformed_data(
-    #     self,
-    #     test_transaction_data  # noqa: F811
-    # ):
-    #     test_input_transaction_data, test_output_transaction_data = test_transaction_data  # noqa: 501
-    #     result = transform_transaction(test_input_transaction_data)
-    #     expected = test_output_transaction_data
-    #     assert result == expected
+    def test_returns_transformed_data(
+        self,
+        test_transaction_data  # noqa: F811
+    ):
+        test_input_transaction_data, test_output_transaction_data = test_transaction_data  # noqa: 501
+        result = transform_transaction(test_input_transaction_data)
+        expected = test_output_transaction_data
+        assert result == expected

--- a/test/test_processor/test_transform_data.py
+++ b/test/test_processor/test_transform_data.py
@@ -108,6 +108,9 @@ class TestApplyDataType:
         assert apply_data_type('2.5', float) == 2.5
         assert apply_data_type('5', float) == 5.0
 
+    def test_returns_zero_when_passed_an_empty_string_and_transaction_table(self):  # noqa: F501
+        assert apply_data_type('', float, "transaction") == 0
+
 
 class TestGetDbCredentials:
     @mock_secretsmanager

--- a/test/test_processor/test_transform_data.py
+++ b/test/test_processor/test_transform_data.py
@@ -102,9 +102,11 @@ class TestApplyDataType:
 
     def test_returns_an_int(self):
         assert apply_data_type('5', int) == 5
+        assert apply_data_type('5.0', int) == 5
 
     def test_returns_a_floating_point_number(self):
         assert apply_data_type('2.5', float) == 2.5
+        assert apply_data_type('5', float) == 5.0
 
 
 class TestGetDbCredentials:

--- a/test/test_processor/test_transform_data.py
+++ b/test/test_processor/test_transform_data.py
@@ -108,7 +108,7 @@ class TestApplyDataType:
         assert apply_data_type('2.5', float) == 2.5
         assert apply_data_type('5', float) == 5.0
 
-    def test_returns_zero_when_passed_an_empty_string_and_transaction_table(self):  # noqa: F501
+    def test_returns_zero_when_passed_an_empty_string_and_transaction_table(self):  # noqa: E501
         assert apply_data_type('', float, "transaction") == 0
 
 

--- a/test/test_processor/test_transform_data.py
+++ b/test/test_processor/test_transform_data.py
@@ -96,8 +96,8 @@ class TestTransformData:
 
 class TestApplyDataType:
     def test_returns_none_when_passed_empty_string(self):
-        assert apply_data_type('', int) == ''
-        assert apply_data_type('', float) == ''
+        assert apply_data_type('', int) == None
+        assert apply_data_type('', float) == None
 
     def test_returns_an_int(self):
         assert apply_data_type('5', int) == 5

--- a/test/test_processor/test_transform_data.py
+++ b/test/test_processor/test_transform_data.py
@@ -96,8 +96,8 @@ class TestTransformData:
 
 class TestApplyDataType:
     def test_returns_none_when_passed_empty_string(self):
-        assert apply_data_type('', int) == None
-        assert apply_data_type('', float) == None
+        assert apply_data_type('', int) is None
+        assert apply_data_type('', float) is None
 
     def test_returns_an_int(self):
         assert apply_data_type('5', int) == 5


### PR DESCRIPTION
Restore transform_payment_type and transform_transaction functions.
Update transform payment to return 0 instead of None when encountering an empty string in transform_transaction.
This mitigates a behaviour of pandas, where null data types cause a column tobe converted to floating points.